### PR TITLE
workaround with --light

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,11 +1,13 @@
 :root {
   --md-primary-fg-color: #0089d6; 
+  --md-primary-fg-color--dark: #333333;
   --md-accent-fg-color: #ffba00;
 }
 
 [data-md-color-scheme="slate"] {
   --md-primary-bg-color: #333333;
   --md-default-bg-color: #333333;
+  --md-primary-fg-color--dark: #ffba00;
 }
 
 .md-typeset table:not([class]) th {


### PR DESCRIPTION
--md-primary-fg-color--light: #333333; won't work
but a workaround is to put --md-primary-fg-color--dark: #ffba00; in dark-mode slate
and --md-primary-fg-color--dark: #333333; in root for light-mode