### PR TITLE
Fix colors for light mode

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,7 +9,6 @@ theme:
   name: material
   palette:
     - media: "(prefers-color-scheme: light)"
-      scheme: default
       toggle:
         icon: material/toggle-switch-off-outline
         name: Switch to dark mode


### PR DESCRIPTION
The default theme was overwriting the custom CSS.

Closes: https://github.com/aad-for-linux/aad-for-linux/issues/30